### PR TITLE
Flow module not detected if importing ng-flow.js or ng-flow.min.js instead of src files.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
     "package.json",
     "bower.json"
   ],
+  "main": "./dist/ng-flow.min.js",
   "dependencies": {
     "angular": "~1",
     "flow.js": "~2"


### PR DESCRIPTION
Added "main" var to work if bower is used with yeoman.
