### PR TITLE
feat: flow-init can use an existing flow object via `flow-object` attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,18 @@ Use `flow-name` attribute and set it to any variable in the scope.
 </div>
 ````
 
+How can I initialize flow with an existing flow object ?
+============
+
+Use `flow-object` attribute and set it with the existing flow object on scope.
+````html
+<div flow-init flow-object="existingFlowObject">
+    ... Flow is initialized with existingFlowObject, no new Flow object  is created ...
+    There are already {{ existingFLowObject.files.length }} files uploaded,
+    which is equal to {{ $flow.files.lengh }}.
+</div>
+````
+
 How can I support older browsers?
 ============
 Go to https://github.com/flowjs/fusty-flow.js

--- a/src/directives/init.js
+++ b/src/directives/init.js
@@ -1,9 +1,11 @@
 angular.module('flow.init', ['flow.provider'])
   .controller('flowCtrl', ['$scope', '$attrs', '$parse', 'flowFactory',
   function ($scope, $attrs, $parse, flowFactory) {
-    // create the flow object
+
     var options = angular.extend({}, $scope.$eval($attrs.flowInit));
-    var flow = flowFactory.create(options);
+
+    // use existing flow object or create a new one
+    var flow  = $scope.$eval($attrs.flowObject) || flowFactory.create(options);
 
     flow.on('catchAll', function (eventName) {
       var args = Array.prototype.slice.call(arguments);

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -3,12 +3,14 @@ describe('init', function() {
   var $rootScope;
   var element;
   var elementScope;
+  var flowFactory;
 
   beforeEach(module('flow'));
 
-  beforeEach(inject(function(_$compile_, _$rootScope_){
+  beforeEach(inject(function(_$compile_, _$rootScope_, _flowFactory_){
     $compile = _$compile_;
     $rootScope = _$rootScope_;
+    flowFactory = _flowFactory_;
     element = $compile('<div flow-init></div>')($rootScope);
     $rootScope.$digest();
     elementScope = element.scope();
@@ -46,5 +48,24 @@ describe('init', function() {
       elementScope.$destroy();
       expect($rootScope.obj.flow).toBeUndefined();
     });
+  });
+
+  describe('flow-object', function () {
+    it('should create a new flow object', function () {
+      spyOn(flowFactory, 'create').andCallThrough();
+      $compile('<div flow-init></div>')($rootScope);
+      $rootScope.$digest();
+      expect(flowFactory.create).toHaveBeenCalled();
+    });
+    it('should init with the existing flow object', function () {
+      $rootScope.existingFlow = flowFactory.create();
+      spyOn(flowFactory, 'create').andCallThrough();
+      element = $compile('<div flow-init flow-object="existingFlow"></div>')($rootScope);
+      elementScope = element.scope();
+      $rootScope.$digest();
+      expect(flowFactory.create).not.toHaveBeenCalled();
+      expect($rootScope.existingFlow).toBe(elementScope.$flow);
+    });
+
   });
 });


### PR DESCRIPTION
@AidasK  This is the pull request that you suggested at https://github.com/flowjs/ng-flow/issues/17#issuecomment-50983622.

Since the options could be useless (when flow-object is set) I am not sure whether I should just ignore them or raise some error when we get both options and an existing flow object. For now I ignored them.
