### PR TITLE
fix(flowDragEnter): wrong triggering of flow-drag-leave

### DIFF
--- a/src/directives/drag-events.js
+++ b/src/directives/drag-events.js
@@ -35,6 +35,7 @@ angular.module('flow.dragEvents', ['flow.init'])
           event.preventDefault();
         });
         element.bind('dragleave drop', function (event) {
+          $timeout.cancel(promise);
           promise = $timeout(function () {
             scope.$eval(attrs.flowDragLeave);
             promise = null;


### PR DESCRIPTION
You can reproduce the issue here: http://flowjs.github.io/ng-flow/
Drag a file into the browser. The drop area will become green. Now don't drop the file, but drag it over some links and other elements to generate `dragleave` events. You'll notice that the drop area isn't green all the time, it blinks.

My browser (just in case): Chrome 37.0.2062.103 m, Windows 7 x64
