### PR TITLE
Remove catchAll listener from flow to prevent multiple event listener registration.

### DIFF
--- a/src/directives/init.js
+++ b/src/directives/init.js
@@ -7,21 +7,23 @@ angular.module('flow.init', ['flow.provider'])
     // use existing flow object or create a new one
     var flow  = $scope.$eval($attrs.flowObject) || flowFactory.create(options);
 
-    flow.off('catchAll');
+    if(!flow.ngFlowInit){
+      flow.ngFlowInit = true;
 
-    flow.on('catchAll', function (eventName) {
-      var args = Array.prototype.slice.call(arguments);
-      args.shift();
-      var event = $scope.$broadcast.apply($scope, ['flow::' + eventName, flow].concat(args));
-      if ({
-        'progress':1, 'filesSubmitted':1, 'fileSuccess': 1, 'fileError': 1, 'complete': 1
-      }[eventName]) {
-        $scope.$apply();
-      }
-      if (event.defaultPrevented) {
-        return false;
-      }
-    });
+      flow.on('catchAll', function (eventName) {
+        var args = Array.prototype.slice.call(arguments);
+        args.shift();
+        var event = $scope.$broadcast.apply($scope, ['flow::' + eventName, flow].concat(args));
+        if ({
+                'progress':1, 'filesSubmitted':1, 'fileSuccess': 1, 'fileError': 1, 'complete': 1
+            }[eventName]) {
+            $scope.$apply();
+        }
+        if (event.defaultPrevented) {
+            return false;
+        }
+      });
+    }
 
     $scope.$flow = flow;
     if ($attrs.hasOwnProperty('flowName')) {

--- a/src/directives/init.js
+++ b/src/directives/init.js
@@ -7,6 +7,8 @@ angular.module('flow.init', ['flow.provider'])
     // use existing flow object or create a new one
     var flow  = $scope.$eval($attrs.flowObject) || flowFactory.create(options);
 
+    flow.off('catchAll');
+
     flow.on('catchAll', function (eventName) {
       var args = Array.prototype.slice.call(arguments);
       args.shift();

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -73,10 +73,10 @@ describe('init', function() {
       elementScope = element.scope();
       $rootScope.$digest();
 
-      expect($rootScope.existingFlow).toBe(elementScope.$flow);
+      spyOn(elementScope.$broadcast, 'apply').andCallThrough();
+      $rootScope.existingFlow.fire('fileProgress', 'file');
 
-      expect($rootScope.existingFlow.events.catchall).toBeDefined();
-      expect($rootScope.existingFlow.events.catchall.length).toBe(1);
+      expect(elementScope.$broadcast.apply.callCount).toEqual(1);
     });
   });
 });

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -66,6 +66,17 @@ describe('init', function() {
       expect(flowFactory.create).not.toHaveBeenCalled();
       expect($rootScope.existingFlow).toBe(elementScope.$flow);
     });
+    it('should not create multiple event handlers for an existing flow object', function () {
+      $rootScope.existingFlow = flowFactory.create();
+      $compile('<div flow-init flow-object="existingFlow"></div>')($rootScope);
+      element = $compile('<div flow-init flow-object="existingFlow"></div>')($rootScope);
+      elementScope = element.scope();
+      $rootScope.$digest();
 
+      expect($rootScope.existingFlow).toBe(elementScope.$flow);
+
+      expect($rootScope.existingFlow.events.catchall).toBeDefined();
+      expect($rootScope.existingFlow.events.catchall.length).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
Similar to issue encountered in #135 - multiple catchall event handlers were being added to the existing flow object. 

Don't expect this would be a breaking change unless someone is adding catchall event handlers directly to a pre-initialized flow object. 

Would probably prefer to see this initialization done by default in factory or config block, but broadcasts containing the flow object become problematic without larger changes.