### PR TITLE
Remove event listeners from flow in flow-init on scope.$destroy

### DIFF
--- a/src/directives/init.js
+++ b/src/directives/init.js
@@ -7,7 +7,7 @@ angular.module('flow.init', ['flow.provider'])
     // use existing flow object or create a new one
     var flow  = $scope.$eval($attrs.flowObject) || flowFactory.create(options);
 
-    flow.on('catchAll', function (eventName) {
+    var catchAllHandler = function(eventName){
       var args = Array.prototype.slice.call(arguments);
       args.shift();
       var event = $scope.$broadcast.apply($scope, ['flow::' + eventName, flow].concat(args));
@@ -19,9 +19,15 @@ angular.module('flow.init', ['flow.provider'])
       if (event.defaultPrevented) {
         return false;
       }
+    };
+
+    flow.on('catchAll', catchAllHandler);
+    $scope.$on('$destroy', function(){
+        flow.off('catchAll', catchAllHandler);
     });
 
     $scope.$flow = flow;
+
     if ($attrs.hasOwnProperty('flowName')) {
       $parse($attrs.flowName).assign($scope, flow);
       $scope.$on('$destroy', function () {

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -66,6 +66,26 @@ describe('init', function() {
       expect(flowFactory.create).not.toHaveBeenCalled();
       expect($rootScope.existingFlow).toBe(elementScope.$flow);
     });
+    it('should remove event handlers from flow when the scope is destroyed', function () {
+      $rootScope.existingFlow = flowFactory.create();
+      element = $compile('<div flow-init flow-object="existingFlow"></div>')($rootScope);
+      elementScope = element.scope();
 
+      $compile('<div flow-init flow-object="existingFlow"></div>')($rootScope);
+      $rootScope.$digest();
+
+      var scopePrototype = Object.getPrototypeOf(elementScope);
+      spyOn(scopePrototype, '$broadcast').andCallThrough();
+
+      $rootScope.existingFlow.fire('fileProgress', 'file');
+      expect(elementScope.$broadcast.callCount).toEqual(2);
+
+      elementScope.$destroy();
+      scopePrototype.$broadcast.reset();
+
+      $rootScope.existingFlow.fire('fileProgress', 'file');
+      expect(elementScope.$broadcast.callCount).toEqual(1);
+
+    });
   });
 });


### PR DESCRIPTION
Reworked pull request #137 to properly clean up event handlers. 
Addresses an issue when an existing flow object is used and flow-init is called multiple times. 
(e.g.: user navigates away from and back to template containing flow-init). 
An event handler was added with each init and would not be removed. 

Can imagine a few different ways to tweak tests, feel free to rework it or recommend changes for consistency, robustness, etc.