### PR TITLE
Specify entry point for CommonJS require() calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ng-flow",
   "version": "2.6.1",
   "description": "Flow.js html5 file upload extension on angular.js framework",
+  "main": "dist/ng-flow-standalone.js",
   "scripts": {
     "test": "grunt test"
   },


### PR DESCRIPTION
Provides a value for the main field in package.json, so Node-style `require.resolve()` implementations can find the standalone ng-flow package.  This allows CommonJS conforming module loaders to consume this package.


### Example
With this change, it is possible to consume this package using Browserify:

`npm install --save ng-flow`

_app.js_
```
var angular = require('angular');
require('ng-flow');
```