### PR TITLE
Add 'main' property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test": "grunt test"
   },
+  "main": "dist/ng-flow.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/flowjs/ng-flow.git"


### PR DESCRIPTION
This enables ng-flow to be used with **gulp+browserify+resolve** combo. Otherwise **resolve** plugin throws the following error:

*Cannot find module 'ng-flow'*