### PR TITLE
Add main entry to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ng-flow",
   "version": "2.6.1",
   "description": "Flow.js html5 file upload extension on angular.js framework",
+  "main": "dist/ng-flow.js",
   "scripts": {
     "test": "grunt test"
   },


### PR DESCRIPTION
It's used when using require, for requiring the main file from other packages.