### PR TITLE
Add a overall files count and uploaded chunk function

### DIFF
--- a/dist/ng-flow-standalone.js
+++ b/dist/ng-flow-standalone.js
@@ -638,6 +638,16 @@
       return ret;
     },
 
+     /**
+     * Returns the count of files in the queue
+     * @function
+     * @returns {number}
+     */
+    getFilesCount: function () {
+      var count = this.files.length;
+      return count;
+    },
+
     /**
      * Returns the total size of all files in bytes.
      * @function
@@ -966,6 +976,22 @@
       // We don't want to lose percentages when an upload is paused
       this._prevProgress = Math.max(this._prevProgress, percent > 0.9999 ? 1 : percent);
       return this._prevProgress;
+    },
+
+     /**
+     * Get current number of complete chunks
+     * @function
+     * @returns {number} from 0 to chunks.length
+     */
+    completeChunks: function () {
+      var completeChunks = 0;
+
+      each(this.chunks, function (c) {
+        if(c.progress() === 1){
+          completeChunks++;
+        }
+      });
+      return completeChunks;
     },
 
     /**


### PR DESCRIPTION
I am the maintainer of the Flowupload app for Nextcloud which uses ng-flow extensively. Recently @TessyPowder added two functions to ng-flow which adds a counter for all files and a function to count already uploaded chunks. I would like to bring these changes to upstream so other projects can use them as well and so they are in the right place.

The original PR on my repository can be found here:

https://github.com/e-alfred/flowupload/pull/57